### PR TITLE
修复多次重复创建 daily 表的问题；ClickHouse 连接添加时区配置

### DIFF
--- a/tushare_integration/db_engine.py
+++ b/tushare_integration/db_engine.py
@@ -113,6 +113,7 @@ class ClickhouseEngine(DBEngine):
             username=settings.database.user,
             password=settings.database.password,
             database=settings.database.db_name,
+            apply_server_timezone=True
         )
 
         self.functions['to_date'] = 'toDate'

--- a/tushare_integration/spiders/stock/basic.py
+++ b/tushare_integration/spiders/stock/basic.py
@@ -109,6 +109,7 @@ class StkPremarket(DailySpider):
     name = "stock/basic/stk_premarket"
     description = '每日股本(盘前数据)'
     api_name = "stk_premarket"
+    custom_settings = {"TABLE_NAME": "stk_premarket"}
 
 
 class StockBakBasicSpider(DailySpider):

--- a/tushare_integration/spiders/tushare.py
+++ b/tushare_integration/spiders/tushare.py
@@ -35,7 +35,7 @@ class TushareSpider(scrapy.Spider):
         return spider
 
     def create_table(self):
-        logging.info(f"create table {self.get_table_name()}")
+        logging.info(f"quest {self.name}: create table {self.get_table_name()}")
 
         self.db_engine = DatabaseEngineFactory.create(self.spider_settings)
         self.db_engine.create_table(self.get_table_name(), self.schema)


### PR DESCRIPTION
基于 https://github.com/zhangbc97/tushare-integration/issues/9 发现的问题进行修复。

解决了 `stock/basic/stk_premarket` 任务的重复创建表问题